### PR TITLE
feat(PAYMENTS-28786): add apple button loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.3",
-        "@xsolla/pay-station-sdk": "^1.0.5",
+        "@xsolla/pay-station-sdk": "^1.0.6",
         "axios": "1.8.2",
         "install": "^0.13.0",
         "npm": "^10.5.1",
@@ -4048,9 +4048,9 @@
       }
     },
     "node_modules/@xsolla/pay-station-sdk": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@xsolla/pay-station-sdk/-/pay-station-sdk-1.0.5.tgz",
-      "integrity": "sha512-I1sKrNiVkQFwoQ+cXgbBMfYkk6+zXQosRWM8b/AL9ECPlpNxWzHICHeur5yaiCbp7tlN2zhPrSGzAlRc+nbKHA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@xsolla/pay-station-sdk/-/pay-station-sdk-1.0.6.tgz",
+      "integrity": "sha512-lnx9k9rNJm/kUolwzC6neKqB318V1A4uiHIo5p7r5Kf4UVzIEYIoAMYBz+I7ZI2ViaLuErAV49Cz1ayA+m1aQA==",
       "license": "ISC",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.3",
-    "@xsolla/pay-station-sdk": "^1.0.5",
+    "@xsolla/pay-station-sdk": "^1.0.6",
     "axios": "1.8.2",
     "install": "^0.13.0",
     "npm": "^10.5.1",

--- a/src/pages/store-page/ui/checkout/form-container/index.tsx
+++ b/src/pages/store-page/ui/checkout/form-container/index.tsx
@@ -1,11 +1,15 @@
+import { Field } from '@xsolla/pay-station-sdk/dist/core/form/field.interface';
+import { forwardRef } from 'react';
+import {
+  alipayId,
+  applePayId,
+  creditCardId,
+} from '../../../../../shared/payment/payment-methods-ids.const.ts';
 import { CreditCardForm } from '../credit-card-form';
 import { DefaultForm } from '../credit-card-form/default-form';
-import { forwardRef } from 'react';
-import { Field } from '@xsolla/pay-station-sdk/dist/core/form/field.interface';
-import { SubmitButton } from '../submit-button';
 import { FormError } from '../form-error';
-import { alipayId, creditCardId } from '../../../../../shared/payment/payment-methods-ids.const.ts';
 import { QrForm } from '../qr-form';
+import { SubmitButton } from '../submit-button';
 
 export const FormContainer = forwardRef<
   HTMLDivElement,
@@ -31,6 +35,7 @@ export const FormContainer = forwardRef<
     },
     ref,
   ) => {
+    const isApplePayForm = pid === applePayId;
     const isCreditCardForm = pid === creditCardId;
     const isQrCode = pid === alipayId && isSecondStep;
 
@@ -57,7 +62,11 @@ export const FormContainer = forwardRef<
           </div>
         )}
         {isSubmitButtonVisible && (
-          <SubmitButton text={submitButtonText} className={'submit-button'} />
+          <SubmitButton
+            text={submitButtonText}
+            className={'submit-button'}
+            showBrandLogo={!isApplePayForm}
+          />
         )}
       </>
     );

--- a/src/pages/store-page/ui/checkout/submit-button/index.tsx
+++ b/src/pages/store-page/ui/checkout/submit-button/index.tsx
@@ -5,11 +5,12 @@ import { SvgIcon } from '../../../../../components/svg-icon/index.tsx';
 import Dron from '../../../../../assets/icons/brand-icon.svg';
 import { useApplePayQrStyles } from '../../../hooks/checkout/use-apple-pay-qr-styles.ts';
 
-export const SubmitButton: FC<{ text?: string; className?: string; isLoading?: boolean }> = ({
-  text,
-  className,
-  isLoading,
-}) => {
+export const SubmitButton: FC<{
+  text?: string;
+  className?: string;
+  isLoading?: boolean;
+  showBrandLogo?: boolean;
+}> = ({ text, className, isLoading, showBrandLogo = true }) => {
   const intl = useIntl();
 
   useApplePayQrStyles();
@@ -23,7 +24,7 @@ export const SubmitButton: FC<{ text?: string; className?: string; isLoading?: b
           intl.formatMessage({ id: 'store.page.checkout.pay-now', defaultMessage: 'Pay now' })
         }
       ></psdk-submit-button>
-      {!isLoading && (
+      {!isLoading && showBrandLogo && (
         <div className='brand-icon-wrapper'>
           <SvgIcon url={Dron} />
         </div>

--- a/src/styles/sdk-controls.styles.ts
+++ b/src/styles/sdk-controls.styles.ts
@@ -187,6 +187,29 @@ export const SDKControlsGlobalStyles = createGlobalStyle`
     }
   }
 
+  psdk-apple-pay {
+    display: block;
+
+    .apple-button-loader {
+      display: none;
+    }
+
+    &.psdk-is-loading {
+      position: relative;
+
+      .apple-button-loader {
+        ${innerLoader('#fff')}
+
+        position: absolute;
+        inset: 0;
+        width: auto;
+        height: 48px;
+        background: #000;
+        border-radius: 5px;
+      }
+    }
+  }
+
   psdk-qr-code {
     display: flex;
     min-height: 170px;


### PR DESCRIPTION
## Summary

Add styles for apple pay button loader

## Changes

- styles for apple pay button loader
- hide xsolla brand logo for apple pay button

## Testing

- loader is visible on submit apple pay button during loading headless-ui component and apple sdk
- xsolla brand logo is not visible on apple pay button

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated changes included
